### PR TITLE
Disabled URL encoding on Cocos2dxDownloader

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxDownloader.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxDownloader.java
@@ -276,7 +276,9 @@ public class Cocos2dxDownloader {
         Cocos2dxDownloader downloader = new Cocos2dxDownloader();
         downloader._id = id;
 
-        downloader._httpClient.setEnableRedirects(true);
+        downloader._httpClient.setEnableRedirects(true);        
+        downloader._httpClient.setURLEncodingEnabled(false);
+
         if (timeoutInSeconds > 0) {
             downloader._httpClient.setTimeout(timeoutInSeconds * 1000);
         }


### PR DESCRIPTION
The current Apple Implementation of Downloader uses the following code (CCDownloader-apple.mm):

`    NSURL *url = [NSURL URLWithString:[NSString stringWithUTF8String:urlStr]];`

Which does not perform any URL encoding of a URL given. This is consistent with all HttpRequests sent through HttpClient.

However the default state of the loopj AsyncHttpClient appears to encode URLs meaning that when a pre-encoded URL is passed (as per compatibility with HttpRequest and apple implementation) it is double-encoded and mangled.

This pull request proposes to disable url encoding for android to make it consistent with other implementations, however this seems like it would be a breaking change for anyone with platform-specific workarounds in place for Android. is this acceptable?

Technically this breaks backward compatibility, however it is breaking compatibility with an inconsistent implementation.